### PR TITLE
Change hook logic to avoid having to enable the module for all apps on LSPosed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 /build
 /captures
+.idea/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.thermatk.android.xf.fakegapps"
         minSdkVersion 15
         targetSdkVersion 30
-        versionCode 3
-        versionName "2.0"
+        versionCode 4
+        versionName "3.0"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/thermatk/android/xf/fakegapps/FakeSignatures.java
+++ b/app/src/main/java/com/thermatk/android/xf/fakegapps/FakeSignatures.java
@@ -7,16 +7,20 @@ import android.content.pm.Signature;
 import android.os.Binder;
 import android.util.Log;
 
-import de.robv.android.xposed.IXposedHookZygoteInit;
+import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
-public class FakeSignatures implements IXposedHookZygoteInit {
+public class FakeSignatures implements IXposedHookLoadPackage {
     @Override
-    public void initZygote(StartupParam startupParam) {
-        final Class<?> ApplicationPackageManager = XposedHelpers.findClass("android.app.ApplicationPackageManager", null);
-        XposedBridge.hookAllMethods(ApplicationPackageManager, "getPackageInfo", new XC_MethodHook() {
+    public void handleLoadPackage(LoadPackageParam loadedPackage) {
+        if (!loadedPackage.packageName.equals("android"))
+            return;
+
+        final Class<?> PackageManagerService = XposedHelpers.findClass("com.android.server.pm.PackageManagerService", loadedPackage.classLoader);
+        XposedBridge.hookAllMethods(PackageManagerService, "generatePackageInfo", new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) {
                 PackageInfo pi = (PackageInfo) param.getResult();

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,7 +2,5 @@
 <resources>
     <string-array name="lsposed_scope" >
         <item>android</item>
-        <item>com.google.android.gms</item>
-        <item>com.android.vending</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Hello @whew-inc!
I did the move to LSPosed, but soon after I found frustrating having to enable FakeGApps for all apps that need GMS signature spoofing. Another consequence of this is that - due to how LSPosed and EdXposed 0.5+ work - there is a small (albeit noticeable) jank on start-up of hooked apps.
So, taking inspiration from [LineageOS for MicroG spoofing patches](https://github.com/lineageos4microg/docker-lineage-cicd/tree/master/src/signature_spoofing_patches), I've slightly reworked the logic to only hook into the PackageManagerService class of the system server, precisely after the [method generatePackageInfo](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/pm/PackageManagerService.java;l=4376). This private method has proved to remain stable throughout the years and is present even on very old Android versions (including 4.0).
I can confirm this works on Android 6 (original Xposed) and 10 (LSPosed), but should work on other versions too.

I've also added .idea folder to gitignore and bumped app version.

**PS:** I've seen that in this fork you have both a branch and a tag named `lsposed`. This caused me some trouble when trying to push the code due to this ambiguity. I think it would be best to delete and recreate the tag with a different name.