### PR TITLE
fix: add spoofing of signingInfo

### DIFF
--- a/app/src/main/java/inc/whew/android/fakegapps/FakeSignatures.java
+++ b/app/src/main/java/inc/whew/android/fakegapps/FakeSignatures.java
@@ -1,8 +1,19 @@
 package inc.whew.android.fakegapps;
 
+import android.annotation.TargetApi;
 import android.content.pm.PackageInfo;
 import android.content.pm.Signature;
+import android.content.pm.SigningInfo;
 import android.os.Build;
+import android.util.ArraySet;
+import android.util.Base64;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Constructor;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.PublicKey;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
@@ -11,10 +22,17 @@ import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 public class FakeSignatures implements IXposedHookLoadPackage {
+    private static final String TAG = "FakeGApps";
+    private static final String _x509cert = "MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK";
+
     @Override
-    public void handleLoadPackage(LoadPackageParam loadedPackage) {
+    public void handleLoadPackage(LoadPackageParam loadedPackage) throws CertificateException {
         if (!loadedPackage.packageName.equals("android"))
             return;
+
+        final byte[] certBytes = Base64.decode(_x509cert, Base64.DEFAULT);
+        final CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+        final Certificate cert = certFactory.generateCertificate(new ByteArrayInputStream(certBytes));
 
         XC_MethodHook hook = new XC_MethodHook() {
             @Override
@@ -23,9 +41,15 @@ public class FakeSignatures implements IXposedHookLoadPackage {
                 if (pi != null) {
                     String packageName = pi.packageName;
                     if (packageName.equals("com.google.android.gms") || packageName.equals("com.android.vending")) {
-                        String sig = "308204433082032ba003020102020900c2e08746644a308d300d06092a864886f70d01010405003074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f6964301e170d3038303832313233313333345a170d3336303130373233313333345a3074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f696430820120300d06092a864886f70d01010105000382010d00308201080282010100ab562e00d83ba208ae0a966f124e29da11f2ab56d08f58e2cca91303e9b754d372f640a71b1dcb130967624e4656a7776a92193db2e5bfb724a91e77188b0e6a47a43b33d9609b77183145ccdf7b2e586674c9e1565b1f4c6a5955bff251a63dabf9c55c27222252e875e4f8154a645f897168c0b1bfc612eabf785769bb34aa7984dc7e2ea2764cae8307d8c17154d7ee5f64a51a44a602c249054157dc02cd5f5c0e55fbef8519fbe327f0b1511692c5a06f19d18385f5c4dbc2d6b93f68cc2979c70e18ab93866b3bd5db8999552a0e3b4c99df58fb918bedc182ba35e003c1b4b10dd244a8ee24fffd333872ab5221985edab0fc0d0b145b6aa192858e79020103a381d93081d6301d0603551d0e04160414c77d8cc2211756259a7fd382df6be398e4d786a53081a60603551d2304819e30819b8014c77d8cc2211756259a7fd382df6be398e4d786a5a178a4763074310b3009060355040613025553311330110603550408130a43616c69666f726e6961311630140603550407130d4d6f756e7461696e205669657731143012060355040a130b476f6f676c6520496e632e3110300e060355040b1307416e64726f69643110300e06035504031307416e64726f6964820900c2e08746644a308d300c0603551d13040530030101ff300d06092a864886f70d010104050003820101006dd252ceef85302c360aaace939bcff2cca904bb5d7a1661f8ae46b2994204d0ff4a68c7ed1a531ec4595a623ce60763b167297a7ae35712c407f208f0cb109429124d7b106219c084ca3eb3f9ad5fb871ef92269a8be28bf16d44c8d9a08e6cb2f005bb3fe2cb96447e868e731076ad45b33f6009ea19c161e62641aa99271dfd5228c5c587875ddb7f452758d661f6cc0cccb7352e424cc4365c523532f7325137593c4ae341f4db41edda0d0b1071a7c440f0fe9ea01cb627ca674369d084bd2fd911ff06cdbf2cfa10dc0f893ae35762919048c7efc64c7144178342f70581c9de573af55b390dd7fdb9418631895d5f759f30112687ff621410c069308a";
+                        pi.signatures = new Signature[]{new Signature(certBytes)};
 
-                        pi.signatures = new Signature[]{new Signature(sig)};
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                            SigningInfo signingInfo = createSigningInfo(new Signature(certBytes), cert.getPublicKey());
+                            if (signingInfo != null) {
+                                pi.signingInfo = signingInfo;
+                            }
+                        }
+
                         param.setResult(pi);
                     }
                 }
@@ -79,5 +103,38 @@ public class FakeSignatures implements IXposedHookLoadPackage {
 
         final Class<?> hookedClass = XposedHelpers.findClass(classToHook, loadedPackage.classLoader);
         XposedBridge.hookAllMethods(hookedClass, "generatePackageInfo", hook);
+    }
+
+    @TargetApi(android.os.Build.VERSION_CODES.P)
+    private SigningInfo createSigningInfo(Signature sig, PublicKey publicKey) {
+        final int SIGNING_BLOCK_V3 = 3;
+        final Signature[] sigs = new Signature[]{sig};
+        final ArraySet<PublicKey> pks = new ArraySet<>();
+        pks.add(publicKey);
+
+        // Unfortunately, SigningDetails is not exported in SDK, so we have to rely on reflection.
+        // Also, public SigningInfo constructor is only available from API 35, so we can't use it.
+        try {
+            Class<?> signingDetailsClass = Class.forName("android.content.pm.SigningDetails");
+            // https://cs.android.com/android/platform/superproject/+/1c19b376095446666df2b2d9290dac3ef71da846:frameworks/base/core/java/android/content/pm/SigningDetails.java;l=146
+            Constructor<?> signingDetailsConstructor = signingDetailsClass.getDeclaredConstructor(
+                Signature[].class, // signatures
+                int.class, // signatureSchemeVersion
+                ArraySet.class, // keys
+                Signature[].class // pastSigningCertificates
+            );
+            Constructor<SigningInfo> signingInfoConstructor = SigningInfo.class.getDeclaredConstructor(signingDetailsClass);
+
+            signingDetailsConstructor.setAccessible(true);
+            signingInfoConstructor.setAccessible(true);
+
+            Object signingDetails = signingDetailsConstructor.newInstance(sigs, SIGNING_BLOCK_V3, pks, null);
+            return signingInfoConstructor.newInstance(signingDetails);
+        } catch (Exception e) {
+            XposedBridge.log(String.format("%s failed to create signingInfo", TAG));
+            XposedBridge.log(e);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Some major Google Apps stopped relying on the deprecated `packageInfo.signature` field and started using
`packageInfo.signingInfo` instead. This commit introduces spoofing for the `signingInfo` field to maintain compatibility.

Unfortunately, spoofing the `signingInfo` field is a little more
involved than spoofing the `signature` field, because the former relies
on a `SigningDetails` class which is not part of the public SDK API [1].
Also, there is no public constructor for `SigningInfo` before SDK 35.
Therefore we rely on reflection to instantiate the `SigningDetails`
object, and to find the associated `SigningInfo` constructor.

The certificate string was converted from hexadecimal to base64
encoding. This change was made to include public key details in
`SigningInfo`, as Java requires PEM data to be loaded from a byte array.
The Android SDK provides a built-in base64 package for decoding
base64-encoded strings, which simplifies handling compared to
hexadecimal strings. Additionally, base64-encoded PEM certificates are
more commonly used.

See also:

- https://github.com/microg/GmsCore/issues/2680
- https://gitlab.e.foundation/e/os/android_frameworks_base/-/commit/2b9c74a4409f41924905c4b28aa900904e442992
- https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/411374

[1] https://cs.android.com/android/platform/superproject/+/1c19b376095446666df2b2d9290dac3ef71da846:frameworks/base/core/java/android/content/pm/SigningDetails.java